### PR TITLE
fix(backend): create `restaurants` table before watchlist FKs to prevent startup failure

### DIFF
--- a/backend/app/db/bootstrap.py
+++ b/backend/app/db/bootstrap.py
@@ -1,0 +1,91 @@
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+
+async def ensure_watchlist_schema(engine: AsyncEngine) -> None:
+    """Create tables required by watchlist flows in fresh environments."""
+    async with engine.begin() as connection:
+        await connection.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS restaurants (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    cuisine TEXT[] NOT NULL,
+                    "priceRange" TEXT,
+                    latitude DOUBLE PRECISION NOT NULL,
+                    longitude DOUBLE PRECISION NOT NULL,
+                    address TEXT,
+                    phone TEXT,
+                    "googlePlaceId" TEXT UNIQUE,
+                    rating DOUBLE PRECISION,
+                    "userRatingsTotal" INTEGER,
+                    "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                )
+                """
+            )
+        )
+        await connection.execute(
+            text(
+                """
+                CREATE INDEX IF NOT EXISTS restaurants_price_range_idx
+                ON restaurants ("priceRange")
+                """
+            )
+        )
+        await connection.execute(
+            text(
+                """
+                CREATE INDEX IF NOT EXISTS restaurants_created_at_desc_idx
+                ON restaurants ("createdAt" DESC)
+                """
+            )
+        )
+
+        await connection.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS users (
+                    id TEXT PRIMARY KEY,
+                    username TEXT NOT NULL UNIQUE,
+                    "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                )
+                """
+            )
+        )
+        await connection.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS user_restaurants (
+                    id TEXT PRIMARY KEY,
+                    "userId" TEXT NOT NULL,
+                    "restaurantId" TEXT NOT NULL,
+                    "addedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    CONSTRAINT user_restaurants_user_fk
+                        FOREIGN KEY ("userId") REFERENCES users(id) ON DELETE CASCADE,
+                    CONSTRAINT user_restaurants_restaurant_fk
+                        FOREIGN KEY ("restaurantId") REFERENCES restaurants(id) ON DELETE CASCADE,
+                    CONSTRAINT user_restaurants_user_restaurant_unique
+                        UNIQUE ("userId", "restaurantId")
+                )
+                """
+            )
+        )
+        await connection.execute(
+            text(
+                """
+                CREATE INDEX IF NOT EXISTS idx_user_restaurants_user_added_at
+                ON user_restaurants ("userId", "addedAt" DESC)
+                """
+            )
+        )
+        await connection.execute(
+            text(
+                """
+                CREATE INDEX IF NOT EXISTS idx_user_restaurants_restaurant_id
+                ON user_restaurants ("restaurantId")
+                """
+            )
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from fastapi.responses import JSONResponse
 from app.api.router import api_router
 from app.core.cache import get_redis_client
 from app.core.config import get_settings
+from app.db.bootstrap import ensure_watchlist_schema
 from app.db.session import engine
 
 settings = get_settings()
@@ -14,6 +15,7 @@ settings = get_settings()
 
 @asynccontextmanager
 async def lifespan(_: FastAPI):
+    await ensure_watchlist_schema(engine)
     yield
     redis = get_redis_client()
     if redis:


### PR DESCRIPTION
### Motivation
- Backend startup was failing with `relation "restaurants" does not exist` when creating `user_restaurants`, causing API/network errors for the frontend. 
- The bootstrap flow needs to create the `restaurants` table (and its indexes) before creating watchlist tables that reference it. 

### Description
- Add `backend/app/db/bootstrap.py` with `ensure_watchlist_schema(engine)` that creates `restaurants`, `users`, and `user_restaurants` with the expected foreign keys and indexes. 
- Create indexes `restaurants_price_range_idx` and `restaurants_created_at_desc_idx` for `restaurants` and preserve the `user_restaurants` indexes and `UNIQUE("userId","restaurantId")` constraint. 
- Call `ensure_watchlist_schema(engine)` from the FastAPI `lifespan` in `backend/app/main.py` before yielding to ensure schema exists on startup. 

### Testing
- Ran `python3 -m compileall backend/app` and it completed successfully. 
- Running the test suite with `pytest` was blocked in this environment due to a missing `python3.14` runtime, so full automated tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d8dcf06f0832491777e8186e55b12)