### PR TITLE
feat(frontend): Apple Store-style dark glass UI and layout improvements

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,35 +1,91 @@
 <script setup>
 import { ref } from 'vue'
+
 const tab = ref('')
 </script>
 
 <template>
-	<q-layout view="lHh Lpr lff">
-		<q-header elevated class="bg-primary text-white">
-			<q-toolbar>
-				<q-toolbar-title>
-					Lazy Meal
-				</q-toolbar-title>
+  <q-layout view="lHh Lpr lff" class="app-layout">
+    <q-header class="app-header q-px-md q-py-sm">
+      <q-toolbar class="toolbar-shell">
+        <q-toolbar-title class="brand-title">Lazy Meal</q-toolbar-title>
 
-				<q-space />
+        <q-space />
 
-				<q-tabs v-model="tab" shrink>
-					<q-route-tab to="/" name="home" label="新增餐廳" />
-					<q-route-tab to="/select" name="select" label="隨機選擇" />
-					<q-route-tab to="/watchlist" name="watchlist" label="口袋名單" />
-				</q-tabs>
-			</q-toolbar>
-		</q-header>
-    <q-page-container> <router-view /> </q-page-container>
+        <q-tabs v-model="tab" shrink class="app-tabs">
+          <q-route-tab to="/" name="home" label="新增餐廳" />
+          <q-route-tab to="/select" name="select" label="隨機選擇" />
+          <q-route-tab to="/watchlist" name="watchlist" label="口袋名單" />
+        </q-tabs>
+      </q-toolbar>
+    </q-header>
 
-    </q-layout>
+    <q-page-container class="page-shell">
+      <router-view />
+    </q-page-container>
+  </q-layout>
 </template>
 
 <style scoped>
-.q-toolbar {
-  min-height: 50px; /* 增加 q-toolbar 高度 */
+.app-layout {
+  background: transparent;
 }
-.q-tabs {
-  min-width: 300px; /* 增加 q-tabs 長度 */
+
+.app-header {
+  background: transparent;
+  backdrop-filter: none;
+}
+
+.toolbar-shell {
+  width: min(1180px, 100%);
+  margin: 8px auto;
+  padding: 8px 18px;
+  border-radius: 30px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: linear-gradient(135deg, rgba(30, 30, 34, 0.74), rgba(19, 19, 22, 0.68));
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(20px);
+}
+
+.brand-title {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.app-tabs {
+  border-radius: 999px;
+  padding: 3px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+:deep(.q-tab) {
+  min-height: 38px;
+  border-radius: 999px;
+  font-weight: 500;
+  opacity: 0.9;
+  transition: all 0.25s ease;
+}
+
+:deep(.q-tab--active) {
+  background: rgba(255, 255, 255, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+  opacity: 1;
+}
+
+.page-shell {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+}
+
+@media (max-width: 768px) {
+  .toolbar-shell {
+    border-radius: 24px;
+    padding: 8px 12px;
+  }
+
+  .page-shell {
+    width: calc(100% - 1rem);
+  }
 }
 </style>

--- a/frontend/src/components/RestaurantList.vue
+++ b/frontend/src/components/RestaurantList.vue
@@ -7,56 +7,60 @@ const { showNotification } = useNotification()
 const watchlistStore = useWatchlistStore()
 const restaurantStore = useRestaurantStore()
 
-// 處理愛心按鈕點擊事件
 const handleToggleWatchlist = async (restaurant) => {
-	const result = await watchlistStore.toggleWatchlist(restaurant)
-	showNotification(result)
+  const result = await watchlistStore.toggleWatchlist(restaurant)
+  showNotification(result)
 }
 </script>
 
 <template>
-    <div class="row q-mt-md">
-        <div class="col-12">
-            <q-list bordered separator class="q-list-custom-style">
-                <q-item
-                    v-for="restaurant in restaurantStore.restaurants"
-                    :key="restaurant.place_id"
-                    clickable v-ripple
-                    class="q-item-custom-style"
-                >
-                    <q-item-section>
-                        <q-item-label lines="1" class="text-h6 text-weight-medium">
-                            {{ restaurant.name }}
-                        </q-item-label>
-                        <q-item-label caption lines="2" class="text-grey-4">
-                            地址：{{ restaurant.address }}
-                        </q-item-label>
-                        <q-item-label caption class="text-grey-4">
-                            評分：{{ restaurant.rating }} ({{ restaurant.userRatingsTotal }} 評價)
-                        </q-item-label>
-                        <q-item-label caption class="text-grey-4">
-                            距離：{{ restaurant.distance_meters.toFixed(2) }} 公尺
-                        </q-item-label>
-                    </q-item-section>
-                    <q-item-section side top>
-                        <q-btn
-                            flat
-                            round
-                            :icon="watchlistStore.isRestaurantInWatchlist(restaurant.place_id) ? 'favorite' : 'favorite_border'"
-                            :color="watchlistStore.isRestaurantInWatchlist(restaurant.place_id) ? 'red' : 'grey'"
-                            size="sm"
-                            @click.stop="handleToggleWatchlist(restaurant)"
-                        />
-                    </q-item-section>
-                </q-item>
-            </q-list>
-        </div>
+  <div class="row q-mt-md">
+    <div class="col-12">
+      <q-list bordered separator class="restaurant-list">
+        <q-item
+          v-for="restaurant in restaurantStore.restaurants"
+          :key="restaurant.place_id"
+          clickable
+          v-ripple
+          class="restaurant-item"
+        >
+          <q-item-section>
+            <q-item-label lines="1" class="text-h6 text-weight-medium">{{ restaurant.name }}</q-item-label>
+            <q-item-label caption lines="2" class="text-grey-4">地址：{{ restaurant.address }}</q-item-label>
+            <q-item-label caption class="text-grey-4">評分：{{ restaurant.rating }} ({{ restaurant.userRatingsTotal }} 評價)</q-item-label>
+            <q-item-label caption class="text-grey-4">距離：{{ restaurant.distance_meters.toFixed(2) }} 公尺</q-item-label>
+          </q-item-section>
+          <q-item-section side top>
+            <q-btn
+              flat
+              round
+              :icon="watchlistStore.isRestaurantInWatchlist(restaurant.place_id) ? 'favorite' : 'favorite_border'"
+              :color="watchlistStore.isRestaurantInWatchlist(restaurant.place_id) ? 'red' : 'grey'"
+              size="sm"
+              @click.stop="handleToggleWatchlist(restaurant)"
+            />
+          </q-item-section>
+        </q-item>
+      </q-list>
     </div>
+  </div>
 </template>
 
 <style scoped>
-.q-item-custom-style {
-	padding-top: 10px;
-	padding-bottom: 10px;
+.restaurant-list {
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.03);
+  overflow: hidden;
+}
+
+.restaurant-item {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  transition: background-color 0.2s ease;
+}
+
+.restaurant-item:hover {
+  background: rgba(255, 255, 255, 0.04);
 }
 </style>

--- a/frontend/src/components/RestaurantSearch.vue
+++ b/frontend/src/components/RestaurantSearch.vue
@@ -2,69 +2,86 @@
 import { ref, onMounted } from 'vue'
 import { useRestaurantStore } from '../stores/restaurantStore'
 import { useNotification } from '../useNotification'
+
 const restaurantStore = useRestaurantStore()
 const { showNotification } = useNotification()
 
 const searchQuery = ref('')
-const userLat = ref(22.6865)	// 預設緯度
-const userLon = ref(120.3015)	// 預設經度
+const userLat = ref(22.6865)
+const userLon = ref(120.3015)
 
 const searchRestaurants = () => {
-	if (searchQuery.value.trim()) {
-		restaurantStore.fetchRestaurants(searchQuery.value, userLat.value, userLon.value)
-	} else {
-		restaurantStore.restaurants = []
-		restaurantStore.error = '請輸入餐廳名稱進行搜索。'
-	}
+  if (searchQuery.value.trim()) {
+    restaurantStore.fetchRestaurants(searchQuery.value, userLat.value, userLon.value)
+  } else {
+    restaurantStore.restaurants = []
+    restaurantStore.error = '請輸入餐廳名稱進行搜索。'
+  }
 }
 
-// 獲取使用者地理位置
 const getUserLocationAndSearch = () => {
-	if (navigator.geolocation) {
-		navigator.geolocation.getCurrentPosition(
-			(position) => {
-				userLat.value = position.coords.latitude
-				userLon.value = position.coords.longitude
-				searchRestaurants() // 獲取位置後再搜尋
-			},
-			() => {
-				showNotification({ success: false, message: '無法獲取您的位置，將使用預設地點搜尋。' })
-				searchRestaurants() // 失敗時使用預設位置搜尋
-			}
-		)
-	}
+  if (navigator.geolocation) {
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        userLat.value = position.coords.latitude
+        userLon.value = position.coords.longitude
+        searchRestaurants()
+      },
+      () => {
+        showNotification({ success: false, message: '無法獲取您的位置，將使用預設地點搜尋。' })
+        searchRestaurants()
+      }
+    )
+  }
 }
 
 onMounted(() => {
-	// searchRestaurants()
-	getUserLocationAndSearch()
+  getUserLocationAndSearch()
 })
 </script>
 
 <template>
-    <div class="row q-mb-lg q-gutter-md items-center">
-        <div class="col-12 col-sm-8">
-            <q-input
-                outlined
-                dark
-                v-model="searchQuery"
-                label="輸入餐廳名稱，例如：麥當勞"
-                clearable
-                @keyup.enter="searchRestaurants"
-            >
-                <template v-slot:append>
-                    <q-icon color="grey-5" name="restaurant" />
-                </template>
-            </q-input>
-        </div>
-        <div class="col-12 col-sm-auto">
-            <q-btn
-            color="primary"
-            label="搜尋"
-            @click="searchRestaurants"
-            :loading="restaurantStore.isLoading"
-            icon="search"
-            />
-        </div>
+  <div class="row q-mb-md q-gutter-md items-center search-row">
+    <div class="col-12 col-sm-8">
+      <q-input
+        outlined
+        dark
+        v-model="searchQuery"
+        label="輸入餐廳名稱，例如：麥當勞"
+        clearable
+        @keyup.enter="searchRestaurants"
+        class="search-input"
+      >
+        <template #append>
+          <q-icon color="grey-5" name="restaurant" />
+        </template>
+      </q-input>
     </div>
+    <div class="col-12 col-sm-auto">
+      <q-btn
+        color="primary"
+        label="搜尋"
+        @click="searchRestaurants"
+        :loading="restaurantStore.isLoading"
+        icon="search"
+        class="search-btn"
+      />
+    </div>
+  </div>
 </template>
+
+<style scoped>
+.search-row {
+  margin-right: 0;
+}
+
+.search-input :deep(.q-field__control) {
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.search-btn {
+  border-radius: 999px;
+  min-width: 100px;
+}
+</style>

--- a/frontend/src/components/WatchlistCard.vue
+++ b/frontend/src/components/WatchlistCard.vue
@@ -5,69 +5,67 @@ import { useNotification } from '../useNotification'
 const { showNotification } = useNotification()
 const watchlistStore = useWatchlistStore()
 
-// 處理從口袋名單移除
 const handleRemoveFromWatchlist = async (placeId) => {
-	const result = await watchlistStore.removeFromWatchlist(placeId)
-	showNotification(result)
+  const result = await watchlistStore.removeFromWatchlist(placeId)
+  showNotification(result)
 }
 </script>
 
 <template>
-	<div class="row q-col-gutter-md">
-		<div
-			class="col-12 col-md-6"
-			v-for="item in watchlistStore.watchlist"
-			:key="item.googlePlaceId"
-		>
-			<q-card dark bordered class="bg-grey-9 watchlist-card">
-				<q-card-section class="flex-grow">
-					<div class="text-h6">{{ item.name }}</div>
-					<div class="text-subtitle2 text-grey-4 row items-center">
-							<q-icon name="star" color="orange" class="q-mr-xs" />
-							{{ item.rating }}
-							<span v-if="item.userRatingsTotal" class="q-ml-xs">
-									({{ item.userRatingsTotal }} 則評論)
-							</span>
-					</div>
-				</q-card-section>
+  <div class="row q-col-gutter-md">
+    <div class="col-12 col-md-6" v-for="item in watchlistStore.watchlist" :key="item.googlePlaceId">
+      <q-card flat bordered class="watchlist-card">
+        <q-card-section class="flex-grow">
+          <div class="text-h6">{{ item.name }}</div>
+          <div class="text-subtitle2 text-grey-4 row items-center">
+            <q-icon name="star" color="orange" class="q-mr-xs" />
+            {{ item.rating }}
+            <span v-if="item.userRatingsTotal" class="q-ml-xs"> ({{ item.userRatingsTotal }} 則評論) </span>
+          </div>
+        </q-card-section>
 
-				<q-separator dark inset />
+        <q-separator dark inset />
 
-				<q-card-section class="q-gutter-sm">
-					<div class="row items-start text-body2 text-grey-4">
-							<q-icon name="place" class="q-mt-xs q-mr-sm" />
-							<div class="col ellipsis">{{ item.address }}</div>
-					</div>
-					<div class="row items-center text-body2 text-grey-4">
-							<q-icon name="directions_walk" class="q-mr-sm" />
-							<div>距離：{{ item.distance_meters ? item.distance_meters.toFixed(0) : 'N/A' }} 公尺</div>
-					</div>
-					<div class="row items-center text-body2 text-grey-4">
-							<q-icon name="paid" class="q-mr-sm" />
-							<div>價位：{{ item.priceRange || '未提供' }} | 菜系：{{ item.cuisine && item.cuisine.length > 0 ? item.cuisine.join(', ') : '未分類' }}</div>
-					</div>
-				</q-card-section>
+        <q-card-section class="q-gutter-sm">
+          <div class="row items-start text-body2 text-grey-4">
+            <q-icon name="place" class="q-mt-xs q-mr-sm" />
+            <div class="col ellipsis">{{ item.address }}</div>
+          </div>
+          <div class="row items-center text-body2 text-grey-4">
+            <q-icon name="directions_walk" class="q-mr-sm" />
+            <div>距離：{{ item.distance_meters ? item.distance_meters.toFixed(0) : 'N/A' }} 公尺</div>
+          </div>
+          <div class="row items-center text-body2 text-grey-4">
+            <q-icon name="paid" class="q-mr-sm" />
+            <div>價位：{{ item.priceRange || '未提供' }} | 菜系：{{ item.cuisine && item.cuisine.length > 0 ? item.cuisine.join(', ') : '未分類' }}</div>
+          </div>
+        </q-card-section>
 
-				<q-separator dark />
+        <q-separator dark />
 
-				<q-card-actions>
-						<div class="text-caption text-grey-7">
-								<q-icon name="event" class="q-mr-xs" />
-								加入於 {{ new Date(item.addedAt).toLocaleString() }}
-						</div>
-						<q-space />
-						<q-btn flat round icon="delete" color="red-4" size="sm" @click="handleRemoveFromWatchlist(item.googlePlaceId)" />
-				</q-card-actions>
-			</q-card>
-		</div>
-	</div>
+        <q-card-actions>
+          <div class="text-caption text-grey-6">
+            <q-icon name="event" class="q-mr-xs" />
+            加入於 {{ new Date(item.addedAt).toLocaleString() }}
+          </div>
+          <q-space />
+          <q-btn flat round icon="delete" color="red-4" size="sm" @click="handleRemoveFromWatchlist(item.googlePlaceId)" />
+        </q-card-actions>
+      </q-card>
+    </div>
+  </div>
 </template>
 
 <style scoped>
 .watchlist-card {
-	border-radius: 12px;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
+  border-radius: 24px;
+  min-height: 240px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.09), rgba(255, 255, 255, 0.03));
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.32);
+  backdrop-filter: blur(14px);
 }
 </style>

--- a/frontend/src/quasar-variables.sass
+++ b/frontend/src/quasar-variables.sass
@@ -1,13 +1,9 @@
-$primary   : #1976D2 // 可以根據你的喜好調整主要顏色
-$secondary : #26A69A
-$accent    : #9C27B0
+$primary   : #4f8cff
+$secondary : #65d6b4
+$accent    : #7b7dff
 
-$dark      : #1d1d1d // 自定義深色背景，使其更接近 Apple 深色模式的顏色
-$dark-page : #121212 // 自定義深色頁面背景
+$dark      : #0f1218
+$dark-page : #0b0e14
 
-// 調整全局圓角半徑
-$generic-border-radius: 12px // 更大的圓角，模仿 Apple 卡片
-
-
-// 定義陰影顏色 (通常是透明度較低的黑色)
-$shadow-color: rgba(0,0,0, 0.3) // 在深色模式下，陰影通常較淺，更像是模糊的效果
+$generic-border-radius: 16px
+$shadow-color: rgba(0, 0, 0, 0.32)

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,79 +1,55 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'SF Pro Text', 'Inter', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: rgba(255, 255, 255, 0.92);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+* {
+  box-sizing: border-box;
 }
-a:hover {
-  color: #535bf2;
+
+html,
+body,
+#app {
+  min-height: 100%;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
-  min-height: 100vh;
+  background:
+    radial-gradient(circle at 15% 10%, rgba(69, 107, 214, 0.18), transparent 34%),
+    radial-gradient(circle at 80% 0%, rgba(84, 174, 255, 0.12), transparent 30%),
+    linear-gradient(180deg, #090b11 0%, #0d1118 45%, #0b0e14 100%);
+  color: rgba(255, 255, 255, 0.9);
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+a {
+  color: inherit;
+  text-decoration: none;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+.glass-panel {
+  border-radius: 30px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.09), rgba(255, 255, 255, 0.03));
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(22px);
 }
 
-.card {
-  padding: 2em;
-}
-
-#app {
-  max-width: 1280px;
+.section-title {
+  font-weight: 650;
+  letter-spacing: 0.01em;
   margin: 0;
-  padding: 2rem;
-  text-align: left;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+.status-banner {
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  backdrop-filter: blur(12px);
 }

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted, ref } from 'vue'
+import { onMounted } from 'vue'
 import { useRestaurantStore } from '../stores/restaurantStore'
 import { useWatchlistStore } from '../stores/watchlistStore'
 import WatchlistCard from '../components/WatchlistCard.vue'
@@ -10,83 +10,81 @@ const watchlistStore = useWatchlistStore()
 const restaurantStore = useRestaurantStore()
 
 onMounted(() => {
-	watchlistStore.fetchWatchlist()
+  watchlistStore.fetchWatchlist()
 })
 </script>
 
 <template>
-	<q-page class="q-pa-md">
-	<h1 class="text-h4 q-mb-md">附近餐廳</h1>
-	<div class="row q-col-gutter-md">
+  <q-page class="home-page q-py-lg">
+    <div class="page-header q-mb-lg">
+      <h1 class="section-title text-h4">附近餐廳</h1>
+      <p class="text-grey-5 q-mt-xs q-mb-none">探索附近餐廳、快速收藏，並維持舒適穩定的瀏覽節奏。</p>
+    </div>
 
-		<!-- section AA -->
-		<div class="col-12 col-md-5">
+    <div class="row q-col-gutter-lg items-start">
+      <div class="col-12 col-lg-5">
+        <section class="glass-panel panel-wrap q-pa-lg">
+          <RestaurantSearch />
 
-			<!-- section A -->
-			<RestaurantSearch />
+          <div class="status-area q-mt-md">
+            <q-banner v-if="restaurantStore.isLoading" rounded class="status-banner bg-blue-1 text-blue-10 q-mb-md">
+              <q-spinner-dots size="2em" /> 載入中...
+            </q-banner>
+            <q-banner v-else-if="restaurantStore.error" rounded class="status-banner bg-red-1 text-red-10 q-mb-md">
+              <q-icon name="error" color="red" /> 錯誤: {{ restaurantStore.error }}
+            </q-banner>
+            <q-banner v-else-if="restaurantStore.restaurants.length === 0" rounded class="status-banner bg-orange-1 text-orange-10 q-mb-md">
+              <q-icon name="warning" color="orange" /> 沒有找到餐廳。
+            </q-banner>
+          </div>
 
-			<!-- section B -->
-			<div class="row">
-				<div class="col-12">
-					<q-banner v-if="restaurantStore.isLoading" rounded class="bg-blue-1 text-blue-8 q-mb-md">
-						<q-spinner-dots size="2em" /> Loading...
-					</q-banner>
-					<q-banner v-else-if="restaurantStore.error" rounded class="bg-red-1 text-red-8 q-mb-md">
-						<q-icon name="error" color="red" /> 錯誤: {{ restaurantStore.error }}
-					</q-banner>
-					<q-banner v-else-if="restaurantStore.restaurants.length === 0" rounded class="bg-orange-1 text-orange-8 q-mb-md">
-						<q-icon name="warning" color="orange" /> 沒有找到餐廳。
-					</q-banner>
-				</div>
-			</div>
+          <RestaurantList />
+        </section>
+      </div>
 
-			<!-- section C -->
-			<RestaurantList/>
-		</div>
+      <div class="col-12 col-lg-7">
+        <section class="glass-panel panel-wrap q-pa-lg">
+          <div class="row items-center q-mb-md no-wrap">
+            <h2 class="section-title text-h5">我的口袋名單</h2>
+          </div>
 
-		<!-- section BB -->
-			
-		<div class="col-12 col-md-7">
-			<div class="row items-center q-mb-md no-wrap">
-				<h2 class="text-h5 q-mr-md q-my-none">我的口袋名單</h2>
-			</div>
-			
-			<q-banner v-if="watchlistStore.isLoading" rounded class="bg-blue-1 text-blue-8 q-mb-md">
-				<q-spinner-dots size="2em" /> 口袋名單載入中...
-			</q-banner>
-			<q-banner v-else-if="watchlistStore.error" rounded class="bg-red-1 text-red-8 q-mb-md">
-				<q-icon name="error" color="red" /> 錯誤：{{ watchlistStore.error }}
-			</q-banner>
-			<q-banner v-else-if="watchlistStore.watchlist.length === 0" rounded class="bg-blue-1 text-blue-8 q-mb-md">
-				<q-icon name="info" color="blue" /> 口袋名單是空的，點擊愛心加入吧！
-			</q-banner>
+          <q-banner v-if="watchlistStore.isLoading" rounded class="status-banner bg-blue-1 text-blue-10 q-mb-md">
+            <q-spinner-dots size="2em" /> 口袋名單載入中...
+          </q-banner>
+          <q-banner v-else-if="watchlistStore.error" rounded class="status-banner bg-red-1 text-red-10 q-mb-md">
+            <q-icon name="error" color="red" /> 錯誤：{{ watchlistStore.error }}
+          </q-banner>
+          <q-banner v-else-if="watchlistStore.watchlist.length === 0" rounded class="status-banner bg-blue-1 text-blue-10 q-mb-md">
+            <q-icon name="info" color="blue" /> 口袋名單是空的，點擊愛心加入吧！
+          </q-banner>
 
-			<!-- watchlist card component -->
-			<WatchlistCard/>
-		</div>
-	</div>
-	</q-page>
+          <WatchlistCard />
+        </section>
+      </div>
+    </div>
+  </q-page>
 </template>
 
 <style scoped>
-
-.q-list-custom-style {
-	border-radius: 8px;
-	overflow: hidden; /* 確保內容在圓角內 */
-	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2), 0 8px 16px rgba(0, 0, 0, 0.1);
+.home-page {
+  padding-inline: 6px;
 }
 
-/* 可以為每個列表項添加一些內邊距或高度調整 */
-.q-item-custom-style {
-	padding-top: 10px;
-	padding-bottom: 10px;
+.page-header {
+  max-width: 720px;
 }
 
-.q-list-custom-style .q-item-label {
-	color: #E0E0E0;
+.panel-wrap {
+  min-height: 540px;
 }
 
-.watchlist-card {
-	border-radius: 8px;
+.status-area {
+  min-height: 80px;
+}
+
+@media (max-width: 1023px) {
+  .panel-wrap {
+    min-height: auto;
+  }
 }
 </style>

--- a/frontend/src/views/SelectView.vue
+++ b/frontend/src/views/SelectView.vue
@@ -1,6 +1,9 @@
 <template>
-  <q-page class="flex column items-center q-pa-md">
-    <div class="q-mb-xl text-center">
+  <q-page class="select-page q-py-lg">
+    <section class="glass-panel hero-panel q-pa-xl text-center">
+      <h1 class="section-title text-h4 q-mb-sm">隨機選擇</h1>
+      <p class="text-grey-5 q-mb-lg">從口袋名單中抽一間，今晚就決定這家。</p>
+
       <q-btn
         @click="handleRandomSelection"
         color="primary"
@@ -9,49 +12,40 @@
         push
         icon="mdi-shuffle-variant"
         :disable="activeWatchlist.length === 0"
+        class="shuffle-btn"
       />
-      <div v-if="hasWatchlistItems" class="text-caption text-grey q-mt-sm">
+      <div v-if="hasWatchlistItems" class="text-caption text-grey-5 q-mt-sm">
         目前有 {{ activeWatchlist.length }} 間餐廳在您的口袋名單中
       </div>
-    </div>
+    </section>
 
-    <transition
-      appear
-      :enter-active-class="`animated ${animation}`"
-      leave-active-class="animated fadeOut"
-    >
-      <div v-if="selectedRestaurant" class="restaurant-card-container">
-        <q-card class="restaurant-card bg-grey-9 flex-grow" flat bordered>
-          <q-card-section class="flex-grow">
-            <div class="text-h6 text-grey-4">{{ selectedRestaurant.name }}</div>
-            <div class="text-subtitle2 row items-center">
-              <q-rating
-                :model-value="selectedRestaurant.rating"
-                max="5"
-                size="sm"
-                color="orange"
-                readonly
-                class="q-mr-sm "
-              />
-              {{ selectedRestaurant.rating }} 
-              <span v-if="selectedRestaurant.user_ratings_total" class="q-ml-xs text-grey-4">
-                ({{ selectedRestaurant.user_ratings_total }} 則評論)
-              </span>
+    <transition appear :enter-active-class="`animated ${animation}`" leave-active-class="animated fadeOut">
+      <div v-if="selectedRestaurant" class="restaurant-card-container q-mt-lg">
+        <q-card class="restaurant-card" flat bordered>
+          <q-card-section>
+            <div class="text-h6">{{ selectedRestaurant.name }}</div>
+            <div class="text-subtitle2 row items-center text-grey-5">
+              <q-rating :model-value="selectedRestaurant.rating" max="5" size="sm" color="orange" readonly />
+              <span class="q-ml-xs">({{ selectedRestaurant.user_ratings_total }} 則評論)</span>
             </div>
           </q-card-section>
 
-          <q-card-section class="q-pt-none">
+          <q-card-section class="q-pt-none text-grey-4">
             <div class="text-body2">
               <q-icon name="mdi-map-marker" class="q-mr-xs" />
               {{ selectedRestaurant.vicinity }}
             </div>
-            <div v-if="selectedRestaurant.opening_hours" class="text-body2 q-mt-sm" :class="selectedRestaurant.opening_hours.open_now ? 'text-positive' : 'text-negative'">
+            <div
+              v-if="selectedRestaurant.opening_hours"
+              class="text-body2 q-mt-sm"
+              :class="selectedRestaurant.opening_hours.open_now ? 'text-positive' : 'text-negative'"
+            >
               <q-icon name="mdi-clock-outline" class="q-mr-xs" />
               {{ selectedRestaurant.opening_hours.open_now ? '營業中' : '已打烊' }}
             </div>
           </q-card-section>
 
-          <q-separator />
+          <q-separator dark />
 
           <q-card-actions align="right">
             <q-btn
@@ -67,48 +61,69 @@
       </div>
     </transition>
 
-    <div v-if="!hasWatchlistItems" class="text-center q-mt-xl">
-        <p class="text-h6">您的口袋名單是空的！</p>
-        <p>請先到首頁搜尋並將餐廳加入口袋名單。</p>
-        <q-btn to="/" color="secondary" label="前往首頁" icon="mdi-home" />
+    <div v-if="!hasWatchlistItems" class="glass-panel empty-state text-center q-mt-lg q-pa-xl">
+      <p class="text-h6 q-mb-sm">您的口袋名單是空的！</p>
+      <p class="q-mb-md text-grey-5">請先到首頁搜尋並將餐廳加入口袋名單。</p>
+      <q-btn to="/" color="secondary" label="前往首頁" icon="mdi-home" />
     </div>
   </q-page>
 </template>
 
 <script setup>
-import { ref, computed } from 'vue';
+import { ref, computed } from 'vue'
 import { useWatchlistStore } from '../stores/watchlistStore'
 import { useSelectionStore } from '../stores/selectionStore'
-import { useQuasar } from 'quasar';
-import { storeToRefs } from 'pinia';
+import { storeToRefs } from 'pinia'
 
-const $q = useQuasar();
-const watchlistStore = useWatchlistStore();
-const selectionStore = useSelectionStore();
-const { selectedRestaurant } = storeToRefs(selectionStore);
+const watchlistStore = useWatchlistStore()
+const selectionStore = useSelectionStore()
+const { selectedRestaurant } = storeToRefs(selectionStore)
 
-const animation = ref('fadeIn');
-const animations = ['jackInTheBox', 'rollIn', 'fadeInUp', 'bounceIn', 'tada'];
+const animation = ref('fadeIn')
+const animations = ['jackInTheBox', 'rollIn', 'fadeInUp', 'bounceIn', 'tada']
 
-const activeWatchlist = computed(() => watchlistStore.watchlist);
-const hasWatchlistItems = computed(() => watchlistStore.watchlist.length > 0);
+const activeWatchlist = computed(() => watchlistStore.watchlist)
+const hasWatchlistItems = computed(() => watchlistStore.watchlist.length > 0)
 
 const handleRandomSelection = () => {
-    selectionStore.clearRestaurant();
+  selectionStore.clearRestaurant()
 
-    const candidates = activeWatchlist.value;
-    if (candidates.length === 0) return;
+  const candidates = activeWatchlist.value
+  if (candidates.length === 0) return
 
-    setTimeout(() => {
-        animation.value = animations[Math.floor(Math.random() * animations.length)];
-        selectionStore.selectNewRestaurant(candidates);
-    }, 200);
-};
+  setTimeout(() => {
+    animation.value = animations[Math.floor(Math.random() * animations.length)]
+    selectionStore.selectNewRestaurant(candidates)
+  }, 200)
+}
 </script>
 
 <style scoped>
+.select-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.hero-panel,
+.empty-state {
+  width: min(760px, 100%);
+}
+
+.shuffle-btn {
+  border-radius: 999px;
+  padding-inline: 12px;
+}
+
 .restaurant-card-container {
-    width: 100%;
-    max-width: 400px;
+  width: min(620px, 100%);
+}
+
+.restaurant-card {
+  border-radius: 30px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.09), rgba(255, 255, 255, 0.02));
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(18px);
 }
 </style>

--- a/frontend/src/views/WatchlistView.vue
+++ b/frontend/src/views/WatchlistView.vue
@@ -1,59 +1,61 @@
 <script setup>
-import { onMounted } from 'vue';
-import { useWatchlistStore } from '../stores/watchlistStore';
-import { useNotification } from '../useNotification';
+import { onMounted } from 'vue'
+import { useWatchlistStore } from '../stores/watchlistStore'
+import { useNotification } from '../useNotification'
 
-const watchlistStore = useWatchlistStore();
-const { showNotification } = useNotification();
+const watchlistStore = useWatchlistStore()
+const { showNotification } = useNotification()
 
 onMounted(() => {
-    watchlistStore.fetchWatchlist();
-});
+  watchlistStore.fetchWatchlist()
+})
 
 const handleRemoveFromWatchlist = async (restaurant) => {
-    const result = await watchlistStore.removeFromWatchlist(restaurant.googlePlaceId);
-    showNotification(result);
-};
+  const result = await watchlistStore.removeFromWatchlist(restaurant.googlePlaceId)
+  showNotification(result)
+}
 </script>
 
 <template>
-  <q-page class="q-pa-md">
-    <h1 class="text-h4 q-mb-md">我的口袋名單</h1>
+  <q-page class="q-py-lg watchlist-page">
+    <div class="q-mb-lg">
+      <h1 class="section-title text-h4 q-mb-sm">我的口袋名單</h1>
+      <p class="text-grey-5 q-ma-none">整理收藏清單，快速比較資訊與距離。</p>
+    </div>
 
     <template v-if="watchlistStore.isLoading">
-      <q-banner rounded class="bg-blue-1 text-blue-8">
-        <template v-slot:avatar>
+      <q-banner rounded class="status-banner bg-blue-1 text-blue-10">
+        <template #avatar>
           <q-spinner-dots size="2em" />
         </template>
         口袋名單載入中...
       </q-banner>
     </template>
     <template v-else-if="watchlistStore.error">
-      <q-banner rounded class="bg-red-1 text-red-8">
-        <template v-slot:avatar>
+      <q-banner rounded class="status-banner bg-red-1 text-red-10">
+        <template #avatar>
           <q-icon name="error" color="red" />
         </template>
         錯誤：{{ watchlistStore.error }}
       </q-banner>
     </template>
     <template v-else-if="watchlistStore.watchlist.length === 0">
-      <q-banner rounded class="bg-blue-1 text-blue-8">
-        <template v-slot:avatar>
+      <q-banner rounded class="status-banner bg-blue-1 text-blue-10">
+        <template #avatar>
           <q-icon name="info" color="blue" />
         </template>
         口袋名單是空的，從主頁搜尋並點擊愛心加入吧！
       </q-banner>
     </template>
 
-    <!-- 口袋名單內容 -->
-    <div v-else class="row q-col-gutter-md">
+    <div v-else class="row q-col-gutter-lg">
       <div
         v-for="restaurant in watchlistStore.watchlist"
         :key="restaurant.googlePlaceId"
         class="col-12 col-sm-6 col-md-4 col-lg-3"
       >
-        <q-card dark flat bordered class="watchlist-card full-height bg-grey-9 flex-grow">
-          <q-card-section class="flex-grow">
+        <q-card flat bordered class="watchlist-card full-height">
+          <q-card-section>
             <div class="text-h6">{{ restaurant.name }}</div>
           </q-card-section>
 
@@ -61,9 +63,7 @@ const handleRemoveFromWatchlist = async (restaurant) => {
 
           <q-card-section>
             <div class="text-caption text-grey-4 q-mt-sm">地址：{{ restaurant.address }}</div>
-            <div class="text-caption text-grey-4">
-              評分：{{ restaurant.rating }} ({{ restaurant.userRatingsTotal }} 則評價)
-            </div>
+            <div class="text-caption text-grey-4">評分：{{ restaurant.rating }} ({{ restaurant.userRatingsTotal }} 則評價)</div>
             <div class="text-caption text-grey-4">
               價位：{{ restaurant.priceRange || '未提供' }} | 菜系：{{
                 restaurant.cuisine && restaurant.cuisine.length > 0 ? restaurant.cuisine.join(', ') : '未分類'
@@ -74,13 +74,21 @@ const handleRemoveFromWatchlist = async (restaurant) => {
           <q-separator dark inset />
 
           <q-card-section>
-            <div class="text-caption text-grey-7 q-mt-sm">
+            <div class="text-caption text-grey-6 q-mt-sm">
               <q-icon name="event" class="q-mr-xs" />加入時間：{{ new Date(restaurant.addedAt).toLocaleString() }}
             </div>
           </q-card-section>
 
           <q-card-actions align="right" class="q-pt-none">
-            <q-btn flat round icon="delete" color="red-4" size="sm" @click="handleRemoveFromWatchlist(restaurant)" aria-label="從口袋名單移除" />
+            <q-btn
+              flat
+              round
+              icon="delete"
+              color="red-4"
+              size="sm"
+              @click="handleRemoveFromWatchlist(restaurant)"
+              aria-label="從口袋名單移除"
+            />
           </q-card-actions>
         </q-card>
       </div>
@@ -89,11 +97,18 @@ const handleRemoveFromWatchlist = async (restaurant) => {
 </template>
 
 <style scoped>
+.watchlist-page {
+  padding-inline: 6px;
+}
 
 .watchlist-card {
-    border-radius: 12px;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+  border-radius: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.02));
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(16px);
 }
 </style>


### PR DESCRIPTION
### Motivation

- Update the frontend visual language to an Apple Store–inspired, dark glassmorphism style (superellipse/pill controls, translucent surfaces, blur, soft shadows) to improve desktop polish and hierarchy.  
- Improve layout stability (consistent content widths, min-height panels, reserved status areas) to reduce layout shifts and give better Lighthouse UX/CLS results.

### Description

- Reworked app chrome and navigation in `frontend/src/App.vue` to a translucent blurred toolbar with pill/superellipse tabs and a fixed content width container.  
- Introduced global dark glass styles in `frontend/src/style.css` (background gradients, `.glass-panel`, `.status-banner`, typography helpers) and tuned Quasar variables in `frontend/src/quasar-variables.sass` for deeper dark tones and radius/shadow values.  
- Restyled page layouts for `frontend/src/views/HomeView.vue`, `frontend/src/views/SelectView.vue`, and `frontend/src/views/WatchlistView.vue` to use glass panels, reserve status/banner space, and enforce min-heights for layout stability.  
- Updated components `frontend/src/components/RestaurantSearch.vue`, `frontend/src/components/RestaurantList.vue`, and `frontend/src/components/WatchlistCard.vue` to match the new pill inputs, glass cards, consistent rounded corners and hover/shadow treatments while preserving existing behavior.

### Testing

- Ran a production build with `yarn --cwd frontend build`, which completed successfully.  
- Launched the dev server with `yarn --cwd frontend dev --host 0.0.0.0 --port 4173` and captured a verification screenshot via Playwright (Chromium failed to launch in this environment but a Firefox run succeeded), producing `artifacts/apple-store-style-home.png` as visual validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d9165aa588324871c56a7fb0d0666)